### PR TITLE
🔀 :: (#26) 회원가입 약관동의 페이지

### DIFF
--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt
@@ -1,0 +1,60 @@
+package com.moizaandroid.moiza.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
+import com.moizaandroid.moiza.ui.theme.Body3
+import com.moizaandroid.moiza.ui.theme.Gray200
+import com.moizaandroid.moiza.ui.theme.Gray400
+
+@Composable
+fun Agreed(
+    text: String,
+    required: Boolean = false,
+    backgroundColor: Color = Color.White,
+    onValueChange: ((Boolean) -> Unit)?,
+    clickDetailBtn: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(color = backgroundColor)
+            .fillMaxWidth()
+    ) {
+        if (onValueChange != null) {
+            MoizaCheckBox(
+                text = if (required) "$text (필수)" else text,
+                onCheckOn = { onValueChange(true) },
+                onCheckOff = { onValueChange(false) },
+                modifier = Modifier.align(
+                    Alignment.CenterStart
+                ),
+                textSize = 14.sp,
+                checkBoxSize = 20.dp
+            )
+
+            Body3(
+                text = "보기",
+                color = Gray400,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .clickable { clickDetailBtn() })
+        }
+    }
+
+}
+
+@Preview
+@Composable
+fun PreviewAgreed() {
+    Agreed(text = "개인정보 취급 방침", onValueChange = {}, backgroundColor = Gray200)
+}

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt
@@ -21,10 +21,10 @@ fun Agreed(
     text: String,
     required: Boolean = false,
     backgroundColor: Color = Color.White,
-    onValueChange: ((Boolean) -> Unit)?,
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
     clickDetailBtn: () -> Unit = {},
     modifier: Modifier = Modifier,
-    checkState: Boolean = false
 ) {
 
     Box(
@@ -32,27 +32,24 @@ fun Agreed(
             .background(color = backgroundColor)
             .fillMaxWidth()
     ) {
-        if (onValueChange != null) {
-            MoizaCheckBox(
-                text = if (required) "$text (필수)" else text,
-                onCheckOn = { onValueChange(true) },
-                onCheckOff = { onValueChange(false) },
-                modifier = Modifier.align(
-                    Alignment.CenterStart
-                ),
-                textSize = 14.sp,
-                checkBoxSize = 20.dp,
-                backgroundColor = backgroundColor,
-                checkState = checkState
-            )
+        MoizaCheckBox(
+            text = if (required) "$text (필수)" else text,
+            checked = checked,
+            modifier = Modifier.align(
+                Alignment.CenterStart
+            ),
+            textSize = 14.sp,
+            checkBoxSize = 20.dp,
+            backgroundColor = backgroundColor,
+            onCheckedChange = onCheckedChange
+        )
 
-            Body3(
-                text = "보기",
-                color = Gray400,
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .clickable { clickDetailBtn() })
-        }
+        Body3(
+            text = "보기",
+            color = Gray400,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .clickable { clickDetailBtn() })
     }
 
 }
@@ -63,7 +60,8 @@ fun PreviewAgreed() {
     Agreed(
         backgroundColor = Gray200,
         text = "개인정보 취급방침",
-        onValueChange = {  },
+        checked = true,
+        onCheckedChange = {},
         required = true,
         clickDetailBtn = {},
         modifier = Modifier.padding(vertical = 12.dp)

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Surface
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,8 +23,10 @@ fun Agreed(
     backgroundColor: Color = Color.White,
     onValueChange: ((Boolean) -> Unit)?,
     clickDetailBtn: () -> Unit = {},
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    checkState: Boolean = false
 ) {
+
     Box(
         modifier = modifier
             .background(color = backgroundColor)
@@ -39,7 +41,9 @@ fun Agreed(
                     Alignment.CenterStart
                 ),
                 textSize = 14.sp,
-                checkBoxSize = 20.dp
+                checkBoxSize = 20.dp,
+                backgroundColor = backgroundColor,
+                checkState = checkState
             )
 
             Body3(
@@ -56,5 +60,12 @@ fun Agreed(
 @Preview
 @Composable
 fun PreviewAgreed() {
-    Agreed(text = "개인정보 취급 방침", onValueChange = {}, backgroundColor = Gray200)
+    Agreed(
+        backgroundColor = Gray200,
+        text = "개인정보 취급방침",
+        onValueChange = {  },
+        required = true,
+        clickDetailBtn = {},
+        modifier = Modifier.padding(vertical = 12.dp)
+    )
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/AgreedButton.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/AgreedButton.kt
@@ -1,0 +1,43 @@
+package com.moizaandroid.moiza.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.moizaandroid.moiza.ui.theme.Black
+
+@Composable
+fun AgreedButton(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    OutlinedButton(
+        onClick = {
+            // do something here
+        },
+        colors = ButtonDefaults.outlinedButtonColors(
+            backgroundColor = Color(0xFF7BB661),
+            contentColor = Color(0xFFF5F5F5),
+            disabledContentColor = Color(0xFF666699)
+        ),
+        enabled = true,
+        modifier = modifier
+    ) {
+        Text(text = text)
+    }
+
+}
+
+@Preview(
+    showBackground = true,
+    showSystemUi = true
+)
+@Composable
+fun PreviewAgreedButton() {
+    AgreedButton("123")
+}

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/AppBar.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/AppBar.kt
@@ -6,64 +6,85 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
+import androidx.compose.material.Icon
+import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.moizaandroid.moiza.R
+import com.moizaandroid.moiza.ui.theme.Body3
 import com.moizaandroid.moiza.ui.theme.Gray300
-import com.moizaandroid.moiza.ui.theme.Typography
 
 @Composable
-fun AppBar(text: String, onBackButtonClick: () -> Unit) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(Color.Transparent)
+fun AppBar(
+    modifier: Modifier = Modifier,
+    text: String,
+    isSignUp: Boolean = false,
+    onBackButtonClick: () -> Unit
+) {
+    Surface(
+        modifier = modifier
     ) {
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp)
                 .background(Color.Transparent)
         ) {
-            Image(
+            Box(
                 modifier = Modifier
-                    .padding(16.dp)
-                    .size(24.dp)
-                    .clickable(
-                        interactionSource = MutableInteractionSource(),
-                        indication = null
-                    ) {
-                        onBackButtonClick()
-                    },
-                imageVector = Icons.Default.ArrowBack,
-                contentDescription = null
-            )
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Color.Transparent)
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .size(24.dp)
+                        .clickable(
+                            interactionSource = MutableInteractionSource(),
+                            indication = null
+                        ) {
+                            onBackButtonClick()
+                        },
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = null
+                )
 
-            Text(
-                text = text,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .wrapContentWidth(Alignment.CenterHorizontally)
-                    .wrapContentHeight(Alignment.CenterVertically)
-                    .padding(start = 54.dp),
-                style = Typography.body1
+                Body3(
+                    text = text,
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .wrapContentWidth(Alignment.CenterHorizontally)
+                        .wrapContentHeight(Alignment.CenterVertically)
+                        .padding(start = 54.dp),
+                )
+
+                if (isSignUp) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_moiza_logo),
+                        contentDescription = "moiza logo",
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .padding(end = 21.dp)
+                    )
+                }
+            }
+            Divider(
+                color = Gray300,
+                thickness = 1.dp
             )
         }
-        Divider(
-            color = Gray300,
-            thickness = 1.dp
-        )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun AppBarPreview() {
-    AppBar(text = "로그인") {}
+    AppBar(text = "로그인", isSignUp = true, onBackButtonClick = {})
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/CheckBox.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/CheckBox.kt
@@ -1,41 +1,45 @@
 package com.moizaandroid.moiza.ui.component
 
-import android.graphics.Paint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Checkbox
-import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.moizaandroid.moiza.ui.theme.Gray300
 import com.moizaandroid.moiza.ui.theme.Orange
-import com.moizaandroid.moiza.ui.theme.Typography
+import com.moizaandroid.moiza.ui.theme.roboto
 
 @Composable
 fun MoizaCheckBox(
     text: String,
     onCheckOn: () -> Unit,
-    onCheckOff: () -> Unit
+    onCheckOff: () -> Unit,
+    checkBoxSize: Dp = 24.dp,
+    textSize: TextUnit = 14.sp,
+    textColor: Color = Color.Black
+
 ) {
     var isChecked by remember { mutableStateOf(false) }
 
-    Row{
-        if(isChecked) {
+    Row {
+        if (isChecked) {
             Box(
                 modifier = Modifier
                     .clip(CircleShape)
-                    .size(24.dp)
+                    .size(checkBoxSize)
                     .border(
                         width = 1.dp,
                         shape = CircleShape,
@@ -52,7 +56,7 @@ fun MoizaCheckBox(
             Box(
                 modifier = Modifier
                     .clip(CircleShape)
-                    .size(24.dp)
+                    .size(checkBoxSize)
                     .border(
                         width = 1.dp,
                         shape = CircleShape,
@@ -66,7 +70,16 @@ fun MoizaCheckBox(
 
         Spacer(modifier = Modifier.size(10.dp))
 
-        Text(text = text, style = Typography.body1, modifier = Modifier.align(CenterVertically))
+        Text(
+            text = text,
+            style = TextStyle(
+                fontSize = textSize,
+                fontFamily = roboto,
+                fontWeight = FontWeight.Normal,
+                color = textColor
+            ),
+            modifier = Modifier.align(CenterVertically)
+        )
     }
 
 }
@@ -74,5 +87,5 @@ fun MoizaCheckBox(
 @Preview(showBackground = true)
 @Composable
 fun PreviewCheckBox() {
-    MoizaCheckBox("hello", {}) {}
+    MoizaCheckBox("hello", {}, {})
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/CheckBox.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/CheckBox.kt
@@ -1,13 +1,16 @@
 package com.moizaandroid.moiza.ui.component
 
+import android.widget.CheckBox
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -28,19 +31,17 @@ import com.moizaandroid.moiza.ui.theme.roboto
 fun MoizaCheckBox(
     modifier: Modifier = Modifier,
     text: String,
-    onCheckOn: () -> Unit,
-    onCheckOff: () -> Unit,
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
     checkBoxSize: Dp = 24.dp,
     textSize: TextUnit = 14.sp,
     textColor: Color = Color.Black,
-    backgroundColor: Color = Color.White
+    backgroundColor: Color = Color.White,
 ) {
-    var isChecked by remember { mutableStateOf(false) }
-
     Row(
         modifier = modifier.background(color = backgroundColor)
     ) {
-        if (isChecked) {
+        if (checked) {
             Box(
                 modifier = Modifier
                     .clip(CircleShape)
@@ -53,10 +54,12 @@ fun MoizaCheckBox(
                     .padding(4.8.dp)
                     .clip(CircleShape)
                     .background(Orange)
-                    .clickable { isChecked = !isChecked }
-            ) {
-                onCheckOn()
-            }
+                    .clickable {
+                        if (onCheckedChange != null) {
+                            onCheckedChange(!checked)
+                        } else null
+                    }
+            )
         } else {
             Box(
                 modifier = Modifier
@@ -67,11 +70,13 @@ fun MoizaCheckBox(
                         shape = CircleShape,
                         color = Gray300
                     )
-                    .clickable { isChecked = !isChecked }
+                    .clickable {
+                        if (onCheckedChange != null) {
+                            onCheckedChange(!checked)
+                        } else null
+                    }
                     .align(CenterVertically)
-            ) {
-                onCheckOff()
-            }
+            )
         }
 
         Spacer(modifier = Modifier.size(10.dp))
@@ -87,10 +92,11 @@ fun MoizaCheckBox(
             modifier = Modifier.align(CenterVertically)
         )
     }
+
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewCheckBox() {
-    MoizaCheckBox(text = "", onCheckOn = { }, onCheckOff = { })
+    MoizaCheckBox(text = "체크 박스", checked = true, onCheckedChange = {})
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/CheckBox.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/CheckBox.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,17 +26,20 @@ import com.moizaandroid.moiza.ui.theme.roboto
 
 @Composable
 fun MoizaCheckBox(
+    modifier: Modifier = Modifier,
     text: String,
     onCheckOn: () -> Unit,
     onCheckOff: () -> Unit,
     checkBoxSize: Dp = 24.dp,
     textSize: TextUnit = 14.sp,
-    textColor: Color = Color.Black
-
+    textColor: Color = Color.Black,
+    backgroundColor: Color = Color.White
 ) {
     var isChecked by remember { mutableStateOf(false) }
 
-    Row {
+    Row(
+        modifier = modifier.background(color = backgroundColor)
+    ) {
         if (isChecked) {
             Box(
                 modifier = Modifier
@@ -63,6 +68,7 @@ fun MoizaCheckBox(
                         color = Gray300
                     )
                     .clickable { isChecked = !isChecked }
+                    .align(CenterVertically)
             ) {
                 onCheckOff()
             }
@@ -81,11 +87,10 @@ fun MoizaCheckBox(
             modifier = Modifier.align(CenterVertically)
         )
     }
-
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewCheckBox() {
-    MoizaCheckBox("hello", {}, {})
+    MoizaCheckBox(text = "", onCheckOn = { }, onCheckOff = { })
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/StepsProgressBar.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/StepsProgressBar.kt
@@ -1,0 +1,81 @@
+package com.moizaandroid.moiza.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moizaandroid.moiza.ui.theme.Blue
+import com.moizaandroid.moiza.ui.theme.Gray300
+
+@Composable
+fun StepsProgressBar(modifier: Modifier = Modifier, numberOfSteps: Int, currentStep: Int) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        for (step in 1..numberOfSteps) {
+            Step(
+                modifier = Modifier.weight(1F),
+                isCompete = step <= currentStep,
+                isCurrent = step == currentStep,
+                isFirst = step == 1
+            )
+        }
+    }
+}
+
+@Composable
+fun Step(modifier: Modifier = Modifier, isCompete: Boolean, isCurrent: Boolean, isFirst: Boolean) {
+    val color = if (isCompete) Blue else Gray300
+    val viewSize = if (isCurrent) 11.dp else 7.dp
+
+    if (isFirst) {
+        Box(
+            modifier = Modifier
+                .size(viewSize)
+                .clip(shape = CircleShape)
+                .background(color)
+        )
+    } else {
+        Box(modifier = modifier) {
+
+            //Line
+            Divider(
+                modifier = Modifier.align(Alignment.CenterStart),
+                color = color,
+                thickness = 2.dp
+            )
+
+            //Circle
+            Box(
+                modifier = Modifier
+                    .size(viewSize)
+                    .align(Alignment.CenterEnd)
+                    .clip(shape = CircleShape)
+                    .background(color)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun StepsProgressBarPreview() {
+    val currentStep = remember { mutableStateOf(2) }
+    StepsProgressBar(
+        modifier = Modifier.fillMaxWidth(),
+        numberOfSteps = 3,
+        currentStep = currentStep.value
+    )
+}

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/component/YellowButton.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/component/YellowButton.kt
@@ -20,12 +20,12 @@ import com.moizaandroid.moiza.ui.theme.body3
 fun YellowButton(
     text: String,
     satisfy: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .height(50.dp)
-            .padding(start = 20.dp, end = 20.dp)
             .fillMaxWidth()
             .clip(RoundedCornerShape(5.dp))
             .background(if (satisfy) Orange else HalfOrange)

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt
@@ -117,11 +117,13 @@ fun SignInScreenCheckBox() {
     Row {
         Spacer(modifier = Modifier.size(20.dp))
 
-        MoizaCheckBox(text = "자동 로그인", onCheckOn = {}, onCheckOff = {})
+        var autoLoginState by remember { mutableStateOf(false) }
+        MoizaCheckBox(text = "자동 로그인", checked = autoLoginState, onCheckedChange = { autoLoginState = it })
 
         Spacer(modifier = Modifier.size(30.dp))
 
-        MoizaCheckBox(text = "아이디 저장", onCheckOn = {}, onCheckOff = {})
+        var saveAccountState by remember { mutableStateOf(false) }
+        MoizaCheckBox(text = "아이디 저장", checked = saveAccountState, onCheckedChange = { saveAccountState = it })
     }
 }
 

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt
@@ -19,10 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.moizaandroid.moiza.R
 import com.moizaandroid.moiza.ui.component.MoizaCheckBox
 import com.moizaandroid.moiza.ui.component.YellowButton
-import com.moizaandroid.moiza.ui.theme.Gray400
-import com.moizaandroid.moiza.ui.theme.MoizaTheme
-import com.moizaandroid.moiza.ui.theme.Typography
-import com.moizaandroid.moiza.ui.theme.body4
+import com.moizaandroid.moiza.ui.theme.*
 
 @Composable
 fun SignInScreen(
@@ -77,40 +74,36 @@ fun SignInScreenBottomMenu(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = "회원가입",
-            style = body4,
-            modifier = Modifier
-                .clickable { onSignUpClick() }
-        )
+        Body4(text = "회원가입", color = Gray400, modifier = Modifier.clickable { onSignUpClick() })
+
         Spacer(modifier = Modifier.size(16.dp))
+
         Divider(
             color = Gray400,
             modifier = Modifier
                 .fillMaxHeight()
                 .width(1.dp)
         )
+
         Spacer(modifier = Modifier.size(16.dp))
-        Text(
-            text = "아이디 찾기",
-            style = body4,
-            modifier = Modifier
-                .clickable { onFindIdClick() }
-        )
+
+        Body4(text = "아이디 찾기", color = Gray400, modifier = Modifier.clickable { onFindIdClick() })
+
         Spacer(modifier = Modifier.size(16.dp))
+
         Divider(
             color = Gray400,
             modifier = Modifier
                 .fillMaxHeight()
                 .width(1.dp)
         )
+
         Spacer(modifier = Modifier.size(16.dp))
-        Text(
+
+        Body4(
             text = "비밀번호 찾기",
-            style = body4,
-            modifier = Modifier
-                .clickable { onFindPasswordClick() }
-        )
+            color = Gray400,
+            modifier = Modifier.clickable { onFindPasswordClick() })
     }
 }
 

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt
@@ -49,7 +49,12 @@ fun SignInScreen(
         SignInScreenCheckBox()
         Spacer(modifier = Modifier.size(45.dp))
 
-        YellowButton(text = "로그인", satisfy = loginBtnState, onClick = onLoginButtonClick)
+        YellowButton(
+            text = "로그인",
+            satisfy = loginBtnState,
+            onClick = onLoginButtonClick,
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
         Spacer(modifier = Modifier.size(40.dp))
 
         SignInScreenBottomMenu(

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpActivity.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpActivity.kt
@@ -2,11 +2,15 @@ package com.moizaandroid.moiza.ui.register
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import com.moizaandroid.moiza.R
+import androidx.activity.compose.setContent
 
 class SignUpActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_sign_up)
+        setContent {
+            SignUpScreen() {
+                finish()
+            }
+        }
     }
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
@@ -1,0 +1,86 @@
+package com.moizaandroid.moiza.ui.register
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moizaandroid.moiza.R
+import com.moizaandroid.moiza.ui.component.AppBar
+import com.moizaandroid.moiza.ui.component.StepsProgressBar
+import com.moizaandroid.moiza.ui.theme.*
+
+@Composable
+fun SignUpScreen(
+    isBackBtnClick: () -> Unit
+) {
+    val currentStep by remember {
+        mutableStateOf(1)
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        AppBar(text = "회원가입", isSignUp = true) {
+            isBackBtnClick()
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        StepsProgressBar(
+            numberOfSteps = 3,
+            currentStep = currentStep,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.height(25.dp))
+
+        SubTitle1(
+            text = stringResource(id = R.string.agreed),
+            color = Color.Black,
+            modifier = Modifier.padding(start = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Body3(
+            text = "원활한 모이자 활동과 서비스 제공을 위해\n꼭 필요한 정보입니다.",
+            color = Gray500,
+            modifier = Modifier.padding(start = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+fun BottomAgreed() {
+    Box(
+        modifier = Modifier
+            .clip(shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp))
+            .background(
+                Gray200
+            )
+    ) {
+
+    }
+}
+
+@Preview(
+    showSystemUi = true,
+    showBackground = true
+)
+@Composable
+fun PreviewSignUpScreen() {
+    BottomAgreed()
+}

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -80,39 +79,28 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
             .padding(horizontal = 22.dp)
             .fillMaxHeight(fraction = 0.8f)
     ) {
-        var agree1 by rememberSaveable{ mutableStateOf(false) }
+        var agree1 by remember { mutableStateOf(false) }
         var agree2 by remember { mutableStateOf(false) }
         var agree3 by remember { mutableStateOf(false) }
         var agree4 by remember { mutableStateOf(false) }
 
-        var emailBtnState by remember {
-            mutableStateOf(
-                false
-            )
-        }
-
         MoizaCheckBox(
             text = "전체 약관 동의",
-            onCheckOn = {
-                agree1 = true
-                agree2 = true
-                agree3 = true
-                agree4 = true
-            },
-            onCheckOff = {
-                agree1 = false
-                agree2 = false
-                agree3 = false
-                agree4 = false
-            },
-            checkState = (agree1 && agree2 && agree3 && agree4),
+            checked = (agree1 && agree2 && agree3 && agree4),
             modifier = Modifier.padding(vertical = 22.dp),
-            backgroundColor = Gray200
+            backgroundColor = Gray200,
+            onCheckedChange = {
+                if (it) {
+                    agree1 = true; agree2 = true; agree3 = true; agree4 = true
+                } else {
+                    agree1 = false; agree2 = false; agree3 = false; agree4 = false
+                }
+            }
         )
 
         Divider(
             color = Gray300,
-            thickness = 1.dp
+            thickness = 0.5.dp
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -120,41 +108,41 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
         Agreed(
             backgroundColor = Gray200,
             text = "개인정보 취급방침",
-            onValueChange = { agree1 = it },
+            checked = agree1,
+            onCheckedChange = { agree1 = it },
             required = true,
             clickDetailBtn = {},
             modifier = Modifier.padding(vertical = 12.dp),
-            checkState = agree1
         )
 
         Agreed(
             backgroundColor = Gray200,
             text = "사용자 이용 약관",
-            onValueChange = { agree2 = it },
+            checked = agree2,
+            onCheckedChange = { agree2 = it },
             required = true,
             clickDetailBtn = {},
             modifier = Modifier.padding(vertical = 12.dp),
-            checkState = agree2
         )
 
         Agreed(
             backgroundColor = Gray200,
             text = "개읹정보 취급방침",
-            onValueChange = { agree3 = it },
+            checked = agree3,
+            onCheckedChange = { agree3 = it },
             required = true,
             clickDetailBtn = {},
             modifier = Modifier.padding(vertical = 12.dp),
-            checkState = agree3
         )
 
         Agreed(
             backgroundColor = Gray200,
             text = "사용자 이용약관",
-            onValueChange = { agree4 = it },
+            checked = agree4,
+            onCheckedChange = { agree4 = it },
             required = true,
             clickDetailBtn = {},
             modifier = Modifier.padding(vertical = 12.dp),
-            checkState = agree4
         )
 
         Spacer(modifier = Modifier.weight(1f))

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
@@ -3,14 +3,18 @@ package com.moizaandroid.moiza.ui.register
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
+import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.moizaandroid.moiza.R
 import com.moizaandroid.moiza.ui.component.Agreed
 import com.moizaandroid.moiza.ui.component.AppBar
@@ -23,7 +27,7 @@ fun SignUpScreen(
     isBackBtnClick: () -> Unit
 ) {
     val currentStep by remember {
-        mutableStateOf(1)
+        mutableStateOf(2)
     }
 
     Column(
@@ -74,16 +78,34 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
                 Gray200
             )
             .padding(horizontal = 22.dp)
+            .fillMaxHeight(fraction = 0.8f)
     ) {
-        var agree1 by remember { mutableStateOf(true) }
-        var agree2 by remember { mutableStateOf(true) }
-        var agree3 by remember { mutableStateOf(true) }
-        var agree4 by remember { mutableStateOf(true) }
+        var agree1 by rememberSaveable{ mutableStateOf(false) }
+        var agree2 by remember { mutableStateOf(false) }
+        var agree3 by remember { mutableStateOf(false) }
+        var agree4 by remember { mutableStateOf(false) }
+
+        var emailBtnState by remember {
+            mutableStateOf(
+                false
+            )
+        }
 
         MoizaCheckBox(
             text = "전체 약관 동의",
-            onCheckOn = { agree1 = true },
-            onCheckOff = { agree2 = false },
+            onCheckOn = {
+                agree1 = true
+                agree2 = true
+                agree3 = true
+                agree4 = true
+            },
+            onCheckOff = {
+                agree1 = false
+                agree2 = false
+                agree3 = false
+                agree4 = false
+            },
+            checkState = (agree1 && agree2 && agree3 && agree4),
             modifier = Modifier.padding(vertical = 22.dp),
             backgroundColor = Gray200
         )
@@ -92,7 +114,7 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
             color = Gray300,
             thickness = 1.dp
         )
-        
+
         Spacer(modifier = Modifier.height(12.dp))
 
         Agreed(
@@ -101,7 +123,8 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
             onValueChange = { agree1 = it },
             required = true,
             clickDetailBtn = {},
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 12.dp),
+            checkState = agree1
         )
 
         Agreed(
@@ -110,7 +133,8 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
             onValueChange = { agree2 = it },
             required = true,
             clickDetailBtn = {},
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 12.dp),
+            checkState = agree2
         )
 
         Agreed(
@@ -119,7 +143,8 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
             onValueChange = { agree3 = it },
             required = true,
             clickDetailBtn = {},
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 12.dp),
+            checkState = agree3
         )
 
         Agreed(
@@ -128,8 +153,37 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
             onValueChange = { agree4 = it },
             required = true,
             clickDetailBtn = {},
-            modifier = Modifier.padding(vertical = 12.dp)
+            modifier = Modifier.padding(vertical = 12.dp),
+            checkState = agree4
         )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        OutlinedButton(
+            onClick = {
+
+            },
+            colors = ButtonDefaults.outlinedButtonColors(
+                backgroundColor = Color.White,
+                contentColor = Color.Black,
+                disabledContentColor = Gray300
+            ),
+            enabled = (agree1 && agree2 && agree3 && agree4),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp)
+        ) {
+            Text(
+                text = "동의하고 계속",
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    fontFamily = roboto,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
     }
 }
 
@@ -139,7 +193,7 @@ fun BottomAgreed(modifier: Modifier = Modifier) {
 )
 @Composable
 fun PreviewSignUpScreen() {
-    SignUpScreen() {
+    SignUpScreen {
 
     }
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/register/SignUpScreen.kt
@@ -3,10 +3,8 @@ package com.moizaandroid.moiza.ui.register
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.material.Divider
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -14,7 +12,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moizaandroid.moiza.R
+import com.moizaandroid.moiza.ui.component.Agreed
 import com.moizaandroid.moiza.ui.component.AppBar
+import com.moizaandroid.moiza.ui.component.MoizaCheckBox
 import com.moizaandroid.moiza.ui.component.StepsProgressBar
 import com.moizaandroid.moiza.ui.theme.*
 
@@ -60,19 +60,76 @@ fun SignUpScreen(
         )
 
         Spacer(modifier = Modifier.weight(1f))
+
+        BottomAgreed()
     }
 }
 
 @Composable
-fun BottomAgreed() {
-    Box(
-        modifier = Modifier
+fun BottomAgreed(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
             .clip(shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp))
             .background(
                 Gray200
             )
+            .padding(horizontal = 22.dp)
     ) {
+        var agree1 by remember { mutableStateOf(true) }
+        var agree2 by remember { mutableStateOf(true) }
+        var agree3 by remember { mutableStateOf(true) }
+        var agree4 by remember { mutableStateOf(true) }
 
+        MoizaCheckBox(
+            text = "전체 약관 동의",
+            onCheckOn = { agree1 = true },
+            onCheckOff = { agree2 = false },
+            modifier = Modifier.padding(vertical = 22.dp),
+            backgroundColor = Gray200
+        )
+
+        Divider(
+            color = Gray300,
+            thickness = 1.dp
+        )
+        
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Agreed(
+            backgroundColor = Gray200,
+            text = "개인정보 취급방침",
+            onValueChange = { agree1 = it },
+            required = true,
+            clickDetailBtn = {},
+            modifier = Modifier.padding(vertical = 12.dp)
+        )
+
+        Agreed(
+            backgroundColor = Gray200,
+            text = "사용자 이용 약관",
+            onValueChange = { agree2 = it },
+            required = true,
+            clickDetailBtn = {},
+            modifier = Modifier.padding(vertical = 12.dp)
+        )
+
+        Agreed(
+            backgroundColor = Gray200,
+            text = "개읹정보 취급방침",
+            onValueChange = { agree3 = it },
+            required = true,
+            clickDetailBtn = {},
+            modifier = Modifier.padding(vertical = 12.dp)
+        )
+
+        Agreed(
+            backgroundColor = Gray200,
+            text = "사용자 이용약관",
+            onValueChange = { agree4 = it },
+            required = true,
+            clickDetailBtn = {},
+            modifier = Modifier.padding(vertical = 12.dp)
+        )
     }
 }
 
@@ -82,5 +139,7 @@ fun BottomAgreed() {
 )
 @Composable
 fun PreviewSignUpScreen() {
-    BottomAgreed()
+    SignUpScreen() {
+
+    }
 }

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/theme/Text.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/theme/Text.kt
@@ -1,0 +1,273 @@
+package com.moizaandroid.moiza.ui.theme
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.moizaandroid.moiza.R
+
+
+val notoSansFamily = FontFamily(
+    Font(R.font.noto_sans_kr_black, FontWeight.Black),
+    Font(R.font.noto_sans_kr_bold, FontWeight.Bold),
+    Font(R.font.noto_sans_kr_medium, FontWeight.Medium),
+    Font(R.font.noto_sans_kr_regular, FontWeight.Normal),
+    Font(R.font.noto_sans_kr_light, FontWeight.Light),
+    Font(R.font.noto_sans_kr_thin, FontWeight.Thin)
+)
+
+val roboto = FontFamily(
+    Font(R.font.rotobo_bold, FontWeight.Bold),
+    Font(R.font.rotobo_medium, FontWeight.Medium),
+    Font(R.font.rotobo_regular, FontWeight.Normal)
+)
+
+
+@Composable
+fun SubTitle1(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 20.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Bold,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+
+@Composable
+fun SubTitle2(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 18.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Bold,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+
+@Composable
+fun SubTitle3(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 18.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Normal,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+
+@Composable
+fun SubTitle4(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 16.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Bold,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+@Composable
+fun Body1(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 16.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Normal,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+
+@Composable
+fun Body2(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 15.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Normal,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+
+@Composable
+fun Body3(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 14.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Normal,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}
+
+
+@Composable
+fun Body4(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = 12.sp,
+        fontFamily = roboto,
+        fontWeight = FontWeight.Normal,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+    )
+}

--- a/presentation/src/main/java/com/moizaandroid/moiza/ui/theme/Type.kt
+++ b/presentation/src/main/java/com/moizaandroid/moiza/ui/theme/Type.kt
@@ -9,20 +9,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.moizaandroid.moiza.R
 
-val notoSansFamily = FontFamily(
-    Font(R.font.noto_sans_kr_black, FontWeight.Black),
-    Font(R.font.noto_sans_kr_bold, FontWeight.Bold),
-    Font(R.font.noto_sans_kr_medium, FontWeight.Medium),
-    Font(R.font.noto_sans_kr_regular, FontWeight.Normal),
-    Font(R.font.noto_sans_kr_light, FontWeight.Light),
-    Font(R.font.noto_sans_kr_thin, FontWeight.Thin)
-)
-
-val roboto = FontFamily(
-    Font(R.font.rotobo_bold, FontWeight.Bold),
-    Font(R.font.rotobo_medium, FontWeight.Medium),
-    Font(R.font.rotobo_regular, FontWeight.Normal)
-)
 
 val Typography = Typography(
     body1 = TextStyle(

--- a/presentation/src/main/res/layout/activity_sign_up.xml
+++ b/presentation/src/main/res/layout/activity_sign_up.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.register.SignUpActivity">
-
-</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="board">Bulletin board</string>
     <string name="notification">Notification</string>
     <string name="profile">Profile</string>
+    
+    <string name="agreed">약관 동의</string>
 
     <string name="popular_content">인기 게시물</string>
 


### PR DESCRIPTION
## PR 정보
* 회원가입 페이지 중 첫 번째 페이지인 약관동의 페이지를 작업합니다.
* 회원가입 코드량이 많은 관계로 세 번 나누어 진행합니다.

## 작업 내용

### Custom Step ProgressBar
<img width="511" alt="image" src="https://user-images.githubusercontent.com/80076029/168464165-280967e6-98ce-4885-bffb-6ced9ff2af29.png">

* 디자인과 똑같이 제공해주는 라이브러리가 없는 관게로 Compose를 통해 작업했습니다.
* 최대 단계와, 현제 단계를 입력하면 그에 맞는 UI를 만들어줍니다.

https://github.com/Software-Meister-High-School-Community/MOIZA_Android/blob/a47ca1c30634b6f2950aab4290fb8b02e6cacd02/presentation/src/main/java/com/moizaandroid/moiza/ui/component/StepsProgressBar.kt#L21-L70

### Agreed Bar
<img width="326" alt="image" src="https://user-images.githubusercontent.com/80076029/168464598-77ad591a-f79d-4f85-ac2e-55d47832527c.png">

* MoizaCheckBox를 응용한 약관 동의 바입니다.

https://github.com/Software-Meister-High-School-Community/MOIZA_Android/blob/a47ca1c30634b6f2950aab4290fb8b02e6cacd02/presentation/src/main/java/com/moizaandroid/moiza/ui/component/Agreed.kt#L19-L55

### 회원가입 페이지 - 약관 동의
<img width="365" alt="image" src="https://user-images.githubusercontent.com/80076029/168464632-6e45a353-4139-4d44-bb05-b9f5e36d683d.png">

* 회원기입 약관 동의 페이지입니다.
https://github.com/Software-Meister-High-School-Community/MOIZA_Android/blob/a47ca1c30634b6f2950aab4290fb8b02e6cacd02/presentation/src/main/java/com/moizaandroid/moiza/ui/login/SignInScreen.kt#L24-L66

Resolves : #45 
